### PR TITLE
Add support for mocha's root hook plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+IntelliJ files
+.idea/

--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ Extension for mocha that expects any assertion to have run in each test otherwis
     const expect = expectAssert(chai.expect);
     ```
 3. Use where you need.
+
+### Alternative global setup with mocha root hook plugin
+
+```
+// hooks.js
+const expectAssert = require('expect-assert');
+chai.expect = expectAssert(chai.expect);
+
+exports.mochaHooks = {
+    afterEach () {
+        expectAssert.assertionTester.call(this);
+    },
+};
+```

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Extension for mocha that expects any assertion to have run in each test otherwis
 ```
 // hooks.js
 const expectAssert = require('expect-assert');
-chai.expect = expectAssert(chai.expect);
+chai.expect = expectAssert(chai.expect); // override expect() everywhere
+```
 
-exports.mochaHooks = {
-    afterEach () {
-        expectAssert.assertionTester.call(this);
-    },
-};
+Register the hooks in mocha:
+
+```
+mocha --require expect-assert/hooks hooks.js
 ```

--- a/hooks.js
+++ b/hooks.js
@@ -1,0 +1,7 @@
+const assertionTester = require('./').assertionTester;
+
+module.exports.mochaHooks = {
+    afterEach () {
+        assertionTester.call(this);
+    }
+};

--- a/index.js
+++ b/index.js
@@ -23,16 +23,23 @@ const functionWrapper = assertion => {
     return assertion;
 };
 
-module.exports = (assertion, test = false) => {
+function assertionTester (test) {
+    if (!assertionRan) {
+        this.currentTest.emit('error', new Error(`Assertion didn't run, check your test: ${this.currentTest.title}`));//eslint-disable-line no-invalid-this
+    }
+    if (!test) {
+        assertionRan = false;
+    }
+}
 
-    afterEach('Assertion tester', function () {
-        if (!assertionRan) {
-            this.currentTest.emit('error',  new Error(`Assertion didn't run, check your test: ${this.currentTest.title}`));//eslint-disable-line no-invalid-this
-        }
-        if(!test) {
-            assertionRan = false;
-        }
-    });
+module.exports = (assertion, test = false) => {
+    if (global.afterEach) {
+        afterEach('Assertion tester', function () {
+            assertionTester.call(this, test);//eslint-disable-line no-invalid-this
+        });
+    }
 
     return functionWrapper(assertion);
 };
+
+module.exports.assertionTester = assertionTester;


### PR DESCRIPTION
I typically use this library like this to override `expect()` globally in one place, to ensure I don't forget to do it in some file:

```js
const expectAssert = require('expect-assert');
chai.expect = expectAssert(chai.expect);
```

Unfortunately, that isn't possible with mocha's parallel mode because global hooks are defined differently there. This PR adds an export that can be used in that case ([mocha docs](https://mochajs.org/#migrating-tests-to-use-root-hook-plugins)) in a backward-compatible way - if you don't import this plugin in a global hook file, you can use it as before.